### PR TITLE
Remove asio_source option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 project(bonefish)
 
 option(shared "build bonefish as a shared library" OFF)
-option(asio_source "include Boost.Asio implementation (src.hpp) in library" ON)
 option(stdlib "When building with clang, you can choose libc++ (default) or libstdc++" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -48,10 +47,8 @@ set(CMAKE_MODULE_PATH
 
 if(shared)
     set(Boost_USE_STATIC_LIBS OFF)
-    add_definitions(-DBOOST_ALL_DYN_LINK)
 else()
     set(Boost_USE_STATIC_LIBS ON)
-    add_definitions(-DBOOST_ASIO_SEPARATE_COMPILATION)
 endif()
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,10 +27,6 @@ set(SOURCES
     bonefish/websocket/websocket_server_impl.cpp
     bonefish/websocket/websocket_transport.cpp)
 
-if (asio_source)
-    list(APPEND SOURCES bonefish/boost/asio.cpp)
-endif ()
-
 set(PUBLIC_HEADERS
     bonefish/rawsocket/rawsocket_listener.hpp
     bonefish/rawsocket/rawsocket_server.hpp

--- a/src/bonefish/boost/asio.cpp
+++ b/src/bonefish/boost/asio.cpp
@@ -1,4 +1,0 @@
-// This is the Include Boost.Asio source code if not used as header-only library.
-#if defined(BOOST_ASIO_DYN_LINK) || defined(BOOST_ASIO_SEPARATE_COMPILATION)
-#include <boost/asio/impl/src.hpp>
-#endif


### PR DESCRIPTION
Using header-only asio gives us consistently 100 KB or more of
binary size savings, while also simplifying build complexities
and the use of bonefish as a library. For shared builds, we don't
want the BOOST_ASIO_DYN_LINK option anyway because it ties us to
asio's ABI, which has been declared as not stable at all.
