### PR TITLE
Performance and api improvements for messaging

### DIFF
--- a/examples/integration.cpp
+++ b/examples/integration.cpp
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+#include <bonefish/native/native_server.hpp>
 #include <bonefish/rawsocket/rawsocket_server.hpp>
 #include <bonefish/rawsocket/tcp_listener.hpp>
 #include <bonefish/rawsocket/uds_listener.hpp>
@@ -52,6 +53,10 @@ int main(int argc, char** argv)
     std::shared_ptr<bonefish::wamp_serializers> serializers =
             std::make_shared<bonefish::wamp_serializers>();
     serializers->add_serializer(std::make_shared<bonefish::msgpack_serializer>());
+
+    std::shared_ptr<bonefish::native_server> native_server =
+            std::make_shared<bonefish::native_server>(io_service, routers);
+    native_server->start();
 
     std::shared_ptr<bonefish::rawsocket_server> rawsocket_server =
             std::make_shared<bonefish::rawsocket_server>(routers, serializers);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,10 @@ set(SOURCES
     bonefish/messages/wamp_message_factory.cpp
     bonefish/messages/wamp_message_type.cpp
     bonefish/messages/wamp_welcome_details.cpp
+    bonefish/native/native_connection.cpp
+    bonefish/native/native_server.cpp
+    bonefish/native/native_server_impl.cpp
+    bonefish/native/native_transport.cpp
     bonefish/rawsocket/rawsocket_server.cpp
     bonefish/rawsocket/rawsocket_server_impl.cpp
     bonefish/rawsocket/rawsocket_transport.cpp
@@ -28,6 +32,12 @@ set(SOURCES
     bonefish/websocket/websocket_transport.cpp)
 
 set(PUBLIC_HEADERS
+    bonefish/native/native_component_endpoint.hpp
+    bonefish/native/native_connector.hpp
+    bonefish/native/native_endpoint.hpp
+    bonefish/native/native_message_queue.hpp
+    bonefish/native/native_server.hpp
+    bonefish/native/native_server_endpoint.hpp
     bonefish/rawsocket/rawsocket_listener.hpp
     bonefish/rawsocket/rawsocket_server.hpp
     bonefish/rawsocket/tcp_listener.hpp
@@ -94,6 +104,9 @@ set(PRIVATE_HEADERS
     bonefish/messages/wamp_welcome_details.hpp
     bonefish/messages/wamp_welcome_message.hpp
     bonefish/messages/wamp_yield_message.hpp
+    bonefish/native/native_connection.hpp
+    bonefish/native/native_server_impl.hpp
+    bonefish/native/native_transport.hpp
     bonefish/rawsocket/rawsocket_connection.hpp
     bonefish/rawsocket/rawsocket_server_impl.hpp
     bonefish/rawsocket/rawsocket_transport.hpp

--- a/src/bonefish/broker/wamp_broker.cpp
+++ b/src/bonefish/broker/wamp_broker.cpp
@@ -122,7 +122,7 @@ void wamp_broker::process_publish_message(const wamp_session_id& session_id,
             // TODO: Improve performance here by offering a transport api that
             //       takes in a pre-serialized buffer. That way we can serialize
             //       the message once and then send it to all of the subscribers.
-            session->get_transport()->send_message(event_message.get());
+            session->get_transport()->send_message(std::move(*event_message));
         }
     }
 
@@ -176,7 +176,7 @@ void wamp_broker::process_subscribe_message(const wamp_session_id& session_id,
     subscribed_message->set_subscription_id(subscription_id);
 
     BONEFISH_TRACE("%1%, %2%", *session % *subscribed_message);
-    session->get_transport()->send_message(subscribed_message.get());
+    session->get_transport()->send_message(std::move(*subscribed_message));
 }
 
 void wamp_broker::process_unsubscribe_message(const wamp_session_id& session_id,
@@ -227,7 +227,7 @@ void wamp_broker::process_unsubscribe_message(const wamp_session_id& session_id,
     unsubscribed_message->set_request_id(unsubscribe_message->get_request_id());
 
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *unsubscribed_message);
-    session_itr->second->get_transport()->send_message(unsubscribed_message.get());
+    session_itr->second->get_transport()->send_message(std::move(*unsubscribed_message));
 }
 
 void wamp_broker::send_error(const std::unique_ptr<wamp_transport>& transport,
@@ -240,7 +240,7 @@ void wamp_broker::send_error(const std::unique_ptr<wamp_transport>& transport,
     error_message->set_error(error);
 
     BONEFISH_TRACE("%1%", *error_message);
-    transport->send_message(error_message.get());
+    transport->send_message(std::move(*error_message));
 }
 
 } // namespace bonefish

--- a/src/bonefish/common/wamp_message_processor.cpp
+++ b/src/bonefish/common/wamp_message_processor.cpp
@@ -86,7 +86,7 @@ void wamp_message_processor::process_message(
             if (!router) {
                 std::unique_ptr<wamp_abort_message> abort_message(new wamp_abort_message);
                 abort_message->set_reason("wamp.error.no_such_realm");
-                transport->send_message(abort_message.get());
+                transport->send_message(std::move(*abort_message));
             } else {
                 wamp_session_id id;
                 auto generator = router->get_session_id_generator();

--- a/src/bonefish/dealer/wamp_dealer.cpp
+++ b/src/bonefish/dealer/wamp_dealer.cpp
@@ -199,7 +199,7 @@ void wamp_dealer::process_call_message(const wamp_session_id& session_id,
     invocation_message->set_arguments_kw(call_message->get_arguments_kw());
 
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *invocation_message);
-    if (!session->get_transport()->send_message(invocation_message.get())) {
+    if (!session->get_transport()->send_message(std::move(*invocation_message))) {
         BONEFISH_TRACE("sending invocation message to callee failed: network failure");
 
         send_error(session_itr->second->get_transport(), call_message->get_type(),
@@ -259,7 +259,7 @@ void wamp_dealer::process_error_message(const wamp_session_id& session_id,
 
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *caller_error_message);
     std::shared_ptr<wamp_session> session = dealer_invocation->get_session();
-    if (!session->get_transport()->send_message(caller_error_message.get())) {
+    if (!session->get_transport()->send_message(std::move(*caller_error_message))) {
         // There is no error message to propogate in this case as this error
         // message was initiated by the callee and sending the callee an error
         // message in response to an error message would not make any sense.
@@ -325,7 +325,7 @@ void wamp_dealer::process_register_message(const wamp_session_id& session_id,
     // that the callee is no longer reachable on this session. So all we
     // do here is trace the fact that this event occured.
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *registered_message);
-    if (!session_itr->second->get_transport()->send_message(registered_message.get())) {
+    if (!session_itr->second->get_transport()->send_message(std::move(*registered_message))) {
         BONEFISH_TRACE("failed to send registered message to caller: network failure");
     }
 }
@@ -386,7 +386,7 @@ void wamp_dealer::process_unregister_message(const wamp_session_id& session_id,
     // that the callee is no longer reachable on this session. So all we
     // do here is trace the fact that this event occured.
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *unregistered_message);
-    if (!session_itr->second->get_transport()->send_message(unregistered_message.get())) {
+    if (!session_itr->second->get_transport()->send_message(std::move(*unregistered_message))) {
         BONEFISH_TRACE("failed to send unregistered message to caller: network failure");
     }
 }
@@ -440,7 +440,7 @@ void wamp_dealer::process_yield_message(const wamp_session_id& session_id,
     // that the caller is no longer reachable on this session. So all
     // we do here is trace the fact that this event occured.
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *result_message);
-    if (!session->get_transport()->send_message(result_message.get())) {
+    if (!session->get_transport()->send_message(std::move(*result_message))) {
         BONEFISH_TRACE("failed to send result message to caller: network failure");
     }
 
@@ -463,7 +463,7 @@ void wamp_dealer::send_error(const std::unique_ptr<wamp_transport>& transport,
     error_message->set_error(error);
 
     BONEFISH_TRACE("%1%", *error_message);
-    if (!transport->send_message(error_message.get())) {
+    if (!transport->send_message(std::move(*error_message))) {
         BONEFISH_TRACE("failed to send error message");
     }
 }

--- a/src/bonefish/messages/wamp_call_message.hpp
+++ b/src/bonefish/messages/wamp_call_message.hpp
@@ -44,7 +44,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     const msgpack::object& get_options() const;
@@ -59,7 +61,6 @@ public:
     void set_arguments_kw(const msgpack::object& arguments_kw);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_options;
@@ -73,8 +74,7 @@ private:
 };
 
 inline wamp_call_message::wamp_call_message()
-    : m_zone()
-    , m_type(wamp_message_type::CALL)
+    : m_type(wamp_message_type::CALL)
     , m_request_id()
     , m_options(msgpack_empty_map())
     , m_procedure()
@@ -113,7 +113,9 @@ inline std::vector<msgpack::object> wamp_call_message::marshal() const
     return fields;
 }
 
-inline void wamp_call_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_call_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() < MIN_FIELDS || fields.size() > MAX_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -123,14 +125,15 @@ inline void wamp_call_message::unmarshal(const std::vector<msgpack::object>& fie
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_options = msgpack::object(fields[2], &m_zone);
-    m_procedure = msgpack::object(fields[3], &m_zone);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_options = fields[2];
+    m_procedure = fields[3];
     if (fields.size() >= 5) {
-        m_arguments = msgpack::object(fields[4], &m_zone);
+        m_arguments = fields[4];
     }
     if (fields.size() == 6) {
-        m_arguments_kw = msgpack::object(fields[5], &m_zone);
+        m_arguments_kw = fields[5];
     }
 }
 
@@ -167,7 +170,7 @@ inline void wamp_call_message::set_request_id(const wamp_request_id& request_id)
 inline void wamp_call_message::set_options(const msgpack::object& options)
 {
     if (options.type == msgpack::type::MAP) {
-        m_options = msgpack::object(options, &m_zone);
+        m_options = msgpack::object(options, get_zone());
     } else {
         throw std::invalid_argument("invalid options");
     }
@@ -181,7 +184,7 @@ inline void wamp_call_message::set_procedure(const std::string& procedure)
 inline void wamp_call_message::set_arguments(const msgpack::object& arguments)
 {
     if (arguments.type == msgpack::type::NIL || arguments.type == msgpack::type::ARRAY) {
-        m_arguments = msgpack::object(arguments, &m_zone);
+        m_arguments = msgpack::object(arguments, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments");
     }
@@ -190,7 +193,7 @@ inline void wamp_call_message::set_arguments(const msgpack::object& arguments)
 inline void wamp_call_message::set_arguments_kw(const msgpack::object& arguments_kw)
 {
     if (arguments_kw.type == msgpack::type::NIL || arguments_kw.type == msgpack::type::MAP) {
-        m_arguments_kw = msgpack::object(arguments_kw, &m_zone);
+        m_arguments_kw = msgpack::object(arguments_kw, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments_kw");
     }

--- a/src/bonefish/messages/wamp_hello_details.cpp
+++ b/src/bonefish/messages/wamp_hello_details.cpp
@@ -21,7 +21,7 @@
 
 namespace bonefish {
 
-msgpack::object wamp_hello_details::marshal(msgpack::zone*) const
+msgpack::object wamp_hello_details::marshal(msgpack::zone& zone) const
 {
     throw std::logic_error("marshal not implemented");
 }

--- a/src/bonefish/messages/wamp_hello_details.hpp
+++ b/src/bonefish/messages/wamp_hello_details.hpp
@@ -20,11 +20,7 @@
 #include <bonefish/roles/wamp_role.hpp>
 #include <bonefish/roles/wamp_role_type.hpp>
 
-#include <cstddef>
-#include <iostream>
 #include <msgpack.hpp>
-#include <stdexcept>
-#include <string>
 #include <unordered_set>
 
 namespace bonefish {
@@ -35,7 +31,7 @@ public:
     wamp_hello_details();
     virtual ~wamp_hello_details();
 
-    msgpack::object marshal(msgpack::zone* zone=nullptr) const;
+    msgpack::object marshal(msgpack::zone& zone) const;
     void unmarshal(const msgpack::object& details);
 
     const std::unordered_set<wamp_role>& get_roles() const;

--- a/src/bonefish/messages/wamp_invocation_message.hpp
+++ b/src/bonefish/messages/wamp_invocation_message.hpp
@@ -44,7 +44,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     wamp_registration_id get_registration_id() const;
@@ -59,7 +61,6 @@ public:
     void set_arguments_kw(const msgpack::object& arguments_kw);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_registration_id;
@@ -73,8 +74,7 @@ private:
 };
 
 inline wamp_invocation_message::wamp_invocation_message()
-    : m_zone()
-    , m_type(wamp_message_type::INVOCATION)
+    : m_type(wamp_message_type::INVOCATION)
     , m_request_id()
     , m_registration_id()
     , m_details(msgpack_empty_map())
@@ -113,7 +113,9 @@ inline std::vector<msgpack::object> wamp_invocation_message::marshal() const
     return fields;
 }
 
-inline void wamp_invocation_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_invocation_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() < MIN_FIELDS || fields.size() > MAX_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -123,14 +125,15 @@ inline void wamp_invocation_message::unmarshal(const std::vector<msgpack::object
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_registration_id = msgpack::object(fields[2]);
-    m_details = msgpack::object(fields[3], &m_zone);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_registration_id = fields[2];
+    m_details = fields[3];
     if (fields.size() >= 5) {
-        m_arguments = msgpack::object(fields[4], &m_zone);
+        m_arguments = fields[4];
     }
     if (fields.size() == 6) {
-        m_arguments_kw = msgpack::object(fields[5], &m_zone);
+        m_arguments_kw = fields[5];
     }
 }
 
@@ -172,7 +175,7 @@ inline void wamp_invocation_message::set_registration_id(const wamp_registration
 inline void wamp_invocation_message::set_details(const msgpack::object& details)
 {
     if (details.type == msgpack::type::MAP) {
-        m_details = msgpack::object(details, &m_zone);
+        m_details = msgpack::object(details, get_zone());
     } else {
         throw std::invalid_argument("invalid details");
     }
@@ -181,7 +184,7 @@ inline void wamp_invocation_message::set_details(const msgpack::object& details)
 inline void wamp_invocation_message::set_arguments(const msgpack::object& arguments)
 {
     if (arguments.type == msgpack::type::NIL || arguments.type == msgpack::type::ARRAY) {
-        m_arguments = msgpack::object(arguments, &m_zone);
+        m_arguments = msgpack::object(arguments, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments");
     }
@@ -190,7 +193,7 @@ inline void wamp_invocation_message::set_arguments(const msgpack::object& argume
 inline void wamp_invocation_message::set_arguments_kw(const msgpack::object& arguments_kw)
 {
     if (arguments_kw.type == msgpack::type::NIL || arguments_kw.type == msgpack::type::MAP) {
-        m_arguments_kw = msgpack::object(arguments_kw, &m_zone);
+        m_arguments_kw = msgpack::object(arguments_kw, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments_kw");
     }

--- a/src/bonefish/messages/wamp_registered_message.hpp
+++ b/src/bonefish/messages/wamp_registered_message.hpp
@@ -41,7 +41,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     wamp_registration_id get_registration_id() const;
@@ -50,7 +52,6 @@ public:
     void set_registration_id(const wamp_registration_id& registration_id);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_registration_id;
@@ -60,8 +61,7 @@ private:
 };
 
 inline wamp_registered_message::wamp_registered_message()
-    : m_zone()
-    , m_type(wamp_message_type::REGISTERED)
+    : m_type(wamp_message_type::REGISTERED)
     , m_request_id()
     , m_registration_id()
 {
@@ -78,7 +78,9 @@ inline std::vector<msgpack::object> wamp_registered_message::marshal() const
     return fields;
 }
 
-inline void wamp_registered_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_registered_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() != NUM_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -88,8 +90,9 @@ inline void wamp_registered_message::unmarshal(const std::vector<msgpack::object
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_registration_id = msgpack::object(fields[2]);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_registration_id = fields[2];
 }
 
 inline wamp_registered_message::~wamp_registered_message()

--- a/src/bonefish/messages/wamp_subscribe_message.hpp
+++ b/src/bonefish/messages/wamp_subscribe_message.hpp
@@ -23,7 +23,6 @@
 #include <bonefish/messages/wamp_message_type.hpp>
 #include <bonefish/utility/wamp_uri.hpp>
 
-#include <cassert>
 #include <cstddef>
 #include <msgpack.hpp>
 #include <ostream>
@@ -43,7 +42,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     const msgpack::object& get_options() const;
@@ -54,7 +55,6 @@ public:
     void set_topic(const std::string& topic);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_options;
@@ -65,8 +65,7 @@ private:
 };
 
 inline wamp_subscribe_message::wamp_subscribe_message()
-    : m_zone()
-    , m_type(wamp_message_type::SUBSCRIBE)
+    : m_type(wamp_message_type::SUBSCRIBE)
     , m_request_id()
     , m_options(msgpack_empty_map())
     , m_topic()
@@ -88,7 +87,9 @@ inline std::vector<msgpack::object> wamp_subscribe_message::marshal() const
     return fields;
 }
 
-inline void wamp_subscribe_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_subscribe_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() != NUM_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -98,9 +99,10 @@ inline void wamp_subscribe_message::unmarshal(const std::vector<msgpack::object>
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_options = msgpack::object(fields[2], &m_zone);
-    m_topic = msgpack::object(fields[3], &m_zone);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_options = fields[2];
+    m_topic = fields[3];
 }
 
 inline wamp_request_id wamp_subscribe_message::get_request_id() const
@@ -125,13 +127,16 @@ inline void wamp_subscribe_message::set_request_id(const wamp_request_id& reques
 
 inline void wamp_subscribe_message::set_options(const msgpack::object& options)
 {
-    assert(options.type == msgpack::type::MAP);
-    m_options = msgpack::object(options, &m_zone);
+    if (options.type == msgpack::type::MAP) {
+        m_options = msgpack::object(options, get_zone());
+    } else {
+        throw std::invalid_argument("invalid options");
+    }
 }
 
 inline void wamp_subscribe_message::set_topic(const std::string& topic)
 {
-    m_topic = msgpack::object(topic, &m_zone);
+    m_topic = msgpack::object(topic, get_zone());
 }
 
 inline std::ostream& operator<<(std::ostream& os, const wamp_subscribe_message& message)

--- a/src/bonefish/messages/wamp_subscribed_message.hpp
+++ b/src/bonefish/messages/wamp_subscribed_message.hpp
@@ -41,7 +41,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     wamp_subscription_id get_subscription_id() const;
@@ -50,7 +52,6 @@ public:
     void set_subscription_id(const wamp_subscription_id& subscription_id);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_subscription_id;
@@ -60,8 +61,7 @@ private:
 };
 
 inline wamp_subscribed_message::wamp_subscribed_message()
-    : m_zone()
-    , m_type(wamp_message_type::SUBSCRIBED)
+    : m_type(wamp_message_type::SUBSCRIBED)
     , m_request_id()
     , m_subscription_id()
 {
@@ -82,7 +82,9 @@ inline std::vector<msgpack::object> wamp_subscribed_message::marshal() const
     return fields;
 }
 
-inline void wamp_subscribed_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_subscribed_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() != NUM_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -92,8 +94,9 @@ inline void wamp_subscribed_message::unmarshal(const std::vector<msgpack::object
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_subscription_id = msgpack::object(fields[2]);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_subscription_id = fields[2];
 }
 
 inline wamp_request_id wamp_subscribed_message::get_request_id() const

--- a/src/bonefish/messages/wamp_unregister_message.hpp
+++ b/src/bonefish/messages/wamp_unregister_message.hpp
@@ -41,7 +41,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     wamp_registration_id get_registration_id() const;
@@ -50,7 +52,6 @@ public:
     void set_registration_id(const wamp_registration_id& registration_id);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_registration_id;
@@ -60,8 +61,7 @@ private:
 };
 
 inline wamp_unregister_message::wamp_unregister_message()
-    : m_zone()
-    , m_type(wamp_message_type::UNREGISTER)
+    : m_type(wamp_message_type::UNREGISTER)
     , m_request_id()
     , m_registration_id()
 {
@@ -82,7 +82,9 @@ inline std::vector<msgpack::object> wamp_unregister_message::marshal() const
     return fields;
 }
 
-inline void wamp_unregister_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_unregister_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() != NUM_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -92,8 +94,9 @@ inline void wamp_unregister_message::unmarshal(const std::vector<msgpack::object
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_registration_id = msgpack::object(fields[2]);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_registration_id = fields[2];
 }
 
 inline wamp_request_id wamp_unregister_message::get_request_id() const

--- a/src/bonefish/messages/wamp_unregistered_message.hpp
+++ b/src/bonefish/messages/wamp_unregistered_message.hpp
@@ -40,13 +40,14 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     void set_request_id(const wamp_request_id& request_id);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
 
@@ -55,8 +56,7 @@ private:
 };
 
 inline wamp_unregistered_message::wamp_unregistered_message()
-    : m_zone()
-    , m_type(wamp_message_type::UNREGISTERED)
+    : m_type(wamp_message_type::UNREGISTERED)
     , m_request_id()
 {
 }
@@ -76,7 +76,9 @@ inline std::vector<msgpack::object> wamp_unregistered_message::marshal() const
     return fields;
 }
 
-inline void wamp_unregistered_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_unregistered_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() != NUM_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -86,7 +88,8 @@ inline void wamp_unregistered_message::unmarshal(const std::vector<msgpack::obje
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
 }
 
 inline wamp_request_id wamp_unregistered_message::get_request_id() const

--- a/src/bonefish/messages/wamp_welcome_details.cpp
+++ b/src/bonefish/messages/wamp_welcome_details.cpp
@@ -80,13 +80,9 @@ void operator<< (object::with_zone& details,
 
 namespace bonefish {
 
-msgpack::object wamp_welcome_details::marshal(msgpack::zone* zone)
+msgpack::object wamp_welcome_details::marshal(msgpack::zone& zone)
 {
-    if (zone) {
-        return msgpack::object(*this, zone);
-    }
-
-    return msgpack::object(*this, &m_zone);
+    return msgpack::object(*this, zone);
 }
 
 void wamp_welcome_details::unmarshal(const msgpack::object& object)

--- a/src/bonefish/messages/wamp_welcome_details.hpp
+++ b/src/bonefish/messages/wamp_welcome_details.hpp
@@ -32,7 +32,7 @@ public:
     wamp_welcome_details();
     virtual ~wamp_welcome_details();
 
-    msgpack::object marshal(msgpack::zone* zone=nullptr);
+    msgpack::object marshal(msgpack::zone& zone);
     void unmarshal(const msgpack::object& details);
 
     const std::unordered_set<wamp_role>& get_roles() const;
@@ -40,13 +40,11 @@ public:
     void add_role(wamp_role&& role);
 
 private:
-    msgpack::zone m_zone;
     std::unordered_set<wamp_role> m_roles;
 };
 
 inline wamp_welcome_details::wamp_welcome_details()
-    : m_zone()
-    , m_roles()
+    : m_roles()
 {
 }
 

--- a/src/bonefish/messages/wamp_yield_message.hpp
+++ b/src/bonefish/messages/wamp_yield_message.hpp
@@ -24,7 +24,6 @@
 #include <bonefish/messages/wamp_message_type.hpp>
 
 #include <cstddef>
-#include <memory>
 #include <msgpack.hpp>
 #include <ostream>
 #include <stdexcept>
@@ -45,7 +44,9 @@ public:
 
     virtual wamp_message_type get_type() const override;
     virtual std::vector<msgpack::object> marshal() const override;
-    virtual void unmarshal(const std::vector<msgpack::object>& fields) override;
+    virtual void unmarshal(
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone) override;
 
     wamp_request_id get_request_id() const;
     const msgpack::object& get_options() const;
@@ -58,7 +59,6 @@ public:
     void set_arguments_kw(const msgpack::object& arguments_kw);
 
 private:
-    msgpack::zone m_zone;
     msgpack::object m_type;
     msgpack::object m_request_id;
     msgpack::object m_options;
@@ -71,8 +71,7 @@ private:
 };
 
 inline wamp_yield_message::wamp_yield_message()
-    : m_zone()
-    , m_type(wamp_message_type::YIELD)
+    : m_type(wamp_message_type::YIELD)
     , m_request_id()
     , m_options(msgpack_empty_map())
     , m_arguments()
@@ -108,7 +107,9 @@ inline std::vector<msgpack::object> wamp_yield_message::marshal() const
     return fields;
 }
 
-inline void wamp_yield_message::unmarshal(const std::vector<msgpack::object>& fields)
+inline void wamp_yield_message::unmarshal(
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
 {
     if (fields.size() < MIN_FIELDS || fields.size() > MAX_FIELDS) {
         throw std::invalid_argument("invalid number of fields");
@@ -118,13 +119,14 @@ inline void wamp_yield_message::unmarshal(const std::vector<msgpack::object>& fi
         throw std::invalid_argument("invalid message type");
     }
 
-    m_request_id = msgpack::object(fields[1]);
-    m_options = msgpack::object(fields[2], &m_zone);
+    acquire_zone(std::move(zone));
+    m_request_id = fields[1];
+    m_options = fields[2];
     if (fields.size() >= 4) {
-        m_arguments = msgpack::object(fields[3], &m_zone);
+        m_arguments = fields[3];
     }
     if (fields.size() == 5) {
-        m_arguments_kw = msgpack::object(fields[4], &m_zone);
+        m_arguments_kw = fields[4];
     }
 }
 
@@ -156,7 +158,7 @@ inline void wamp_yield_message::set_request_id(const wamp_request_id& request_id
 inline void wamp_yield_message::set_options(const msgpack::object& options)
 {
     if (options.type == msgpack::type::MAP) {
-        m_options = msgpack::object(options, &m_zone);
+        m_options = msgpack::object(options, get_zone());
     } else {
         throw std::invalid_argument("invalid options");
     }
@@ -165,7 +167,7 @@ inline void wamp_yield_message::set_options(const msgpack::object& options)
 inline void wamp_yield_message::set_arguments(const msgpack::object& arguments)
 {
     if (arguments.type == msgpack::type::NIL || arguments.type == msgpack::type::ARRAY) {
-        m_arguments = msgpack::object(arguments, &m_zone);
+        m_arguments = msgpack::object(arguments, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments");
     }
@@ -174,7 +176,7 @@ inline void wamp_yield_message::set_arguments(const msgpack::object& arguments)
 inline void wamp_yield_message::set_arguments_kw(const msgpack::object& arguments_kw)
 {
     if (arguments_kw.type == msgpack::type::NIL || arguments_kw.type == msgpack::type::MAP) {
-        m_arguments_kw = msgpack::object(arguments_kw, &m_zone);
+        m_arguments_kw = msgpack::object(arguments_kw, get_zone());
     } else {
         throw std::invalid_argument("invalid arguments_kw");
     }

--- a/src/bonefish/native/native_component_endpoint.hpp
+++ b/src/bonefish/native/native_component_endpoint.hpp
@@ -1,0 +1,129 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_COMPONENT_ENDPOINT_HPP
+#define BONEFISH_NATIVE_COMPONENT_ENDPOINT_HPP
+
+#include <bonefish/native/native_endpoint.hpp>
+#include <bonefish/native/native_server_endpoint.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <msgpack.hpp>
+#include <vector>
+
+namespace bonefish {
+
+/*!
+ * A class that provides the concept of an endpoint for communicating natively
+ * between a component and a server. Communication is message based and conducted
+ * in a zero copy manner, as ownership of the message is passed via the endpoint.
+ */
+class native_component_endpoint :
+        public native_endpoint,
+        public std::enable_shared_from_this<native_component_endpoint>
+{
+public:
+    /*!
+     * Defines a handler to be invoked by a server to indicate that a component
+     * initiated connection with the server has been created. This allows a
+     * component to synchronize with the server when creating the initial connection.
+     * The server's endpoint is passed to this handler which then allows the component
+     * to start sending messsages to the server.
+     */
+    using connected_handler =
+            std::function<void(const std::shared_ptr<native_server_endpoint>&)>;
+
+    /*!
+     * Defines a handler to be invoked by the server to indicate that a component
+     * initiated disconnect with the server has been processed. This allows a
+     * component to synchonize with the server when disconnecting.
+     */
+    using disconnected_handler = std::function<void()>;
+
+    /*!
+     * Defines a handler to be invoked by the server to indicate that it wants
+     * to disconnect from the component. This allows a server to synchonize with
+     * the component when disconnecting. The component is required to notify the
+     * server endpoint via its `disconnected_handler` when it is complete.
+     */
+    using disconnect_handler = std::function<void()>;
+
+public:
+    native_component_endpoint();
+
+    const connected_handler& get_connected_handler() const;
+    void set_connected_handler(connected_handler&& handler);
+
+    const disconnected_handler& get_disconnected_handler() const;
+    void set_disconnected_handler(disconnected_handler&& handler);
+
+    const disconnect_handler& get_disconnect_handler() const;
+    void set_disconnect_handler(disconnected_handler&& handler);
+
+private:
+    connected_handler m_connected_handler;
+    disconnected_handler m_disconnected_handler;
+    disconnect_handler m_disconnect_handler;
+};
+
+inline native_component_endpoint::native_component_endpoint()
+    : m_connected_handler()
+    , m_disconnected_handler()
+    , m_disconnect_handler()
+{
+}
+
+inline const native_component_endpoint::connected_handler&
+native_component_endpoint::get_connected_handler() const
+{
+    return m_connected_handler;
+}
+
+inline void native_component_endpoint::set_connected_handler(
+        connected_handler&& handler)
+{
+    m_connected_handler = std::move(handler);
+}
+
+inline const native_component_endpoint::disconnected_handler&
+native_component_endpoint::get_disconnected_handler() const
+{
+    return m_disconnected_handler;
+}
+
+inline void native_component_endpoint::set_disconnected_handler(
+        disconnected_handler&& handler)
+{
+    m_disconnected_handler = std::move(handler);
+}
+
+inline const native_component_endpoint::disconnect_handler&
+native_component_endpoint::get_disconnect_handler() const
+{
+    return m_disconnect_handler;
+}
+
+inline void native_component_endpoint::set_disconnect_handler(
+        disconnect_handler&& handler)
+{
+    m_disconnect_handler = std::move(handler);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_COMPONENT_ENDPOINT_HPP

--- a/src/bonefish/native/native_connection.cpp
+++ b/src/bonefish/native/native_connection.cpp
@@ -1,0 +1,77 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/native/native_connection.hpp>
+
+namespace bonefish {
+
+const std::shared_ptr<native_server_endpoint>& native_connection::get_server_endpoint()
+{
+    if (!m_server_endpoint) {
+        m_server_endpoint = std::make_shared<native_server_endpoint>();
+        std::weak_ptr<native_connection> weak_this = this->shared_from_this();
+
+        m_server_endpoint->set_send_message_handler(
+            [this, weak_this](std::vector<msgpack::object>&& fields,
+                    msgpack::zone&& zone) {
+                auto shared_this = weak_this.lock();
+                if (!shared_this) {
+                    // This will get thrown in the context of the component.
+                    throw std::runtime_error("connection closed");
+                }
+
+                m_receive_message_queue.push_message(
+                        std::move(fields), std::move(zone));
+
+                m_io_service.post([this, weak_this]() {
+                    auto shared_this = weak_this.lock();
+                    if (!shared_this) {
+                        // FIXME: This will cause the io service to bail!!
+                        throw std::runtime_error("connection closed");
+                    }
+
+                    msgpack::zone zone;
+                    std::vector<msgpack::object> fields;
+                    m_receive_message_queue.pop_message(fields, zone);
+                    m_receive_message_handler(
+                            shared_this, std::move(fields), std::move(zone));
+                });
+            }
+        );
+
+        m_server_endpoint->set_disconnected_handler([this, weak_this](){
+            auto shared_this = weak_this.lock();
+            if (!shared_this) {
+                // This will get thrown in the context of the component.
+                throw std::runtime_error("connection closed");
+            }
+
+            m_io_service.post([this, weak_this]() {
+                auto shared_this = weak_this.lock();
+                if (!shared_this) {
+                    // FIXME: This will cause the io service to bail!!
+                    throw std::runtime_error("connection closed");
+                }
+
+                m_disconnected_handler();
+            });
+        });
+    }
+
+    return m_server_endpoint;
+}
+
+} // namespace bonefish

--- a/src/bonefish/native/native_connection.hpp
+++ b/src/bonefish/native/native_connection.hpp
@@ -1,0 +1,198 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_CONNECTION_HPP
+#define BONEFISH_NATIVE_CONNECTION_HPP
+
+#include <bonefish/common/wamp_connection_base.hpp>
+#include <bonefish/native/native_component_endpoint.hpp>
+#include <bonefish/native/native_message_queue.hpp>
+#include <bonefish/native/native_server_endpoint.hpp>
+#include <bonefish/trace/trace.hpp>
+
+#include <boost/asio/io_service.hpp>
+#include <functional>
+#include <memory>
+#include <msgpack.hpp>
+
+namespace bonefish {
+
+/*!
+ * A class that represents a connection to the server from a native
+ * WAMP component. The connection is message based as it provides
+ * direct in process communication with the component. Messages that
+ * are received from the component are temporarily queued for processing.
+ */
+class native_connection :
+        public wamp_connection_base,
+        public std::enable_shared_from_this<native_connection>
+{
+public:
+    /*!
+     * Defines a handler for receiving messages. The handler passes along
+     * ownership of the message fields and the zone used to allocate them.
+     *
+     * @param connection The connection the message was received on.
+     * @param fields The message fields.
+     * @param zone The zone the message fields were allocated from.
+     */
+    using receive_message_handler =
+            std::function<void(
+                    const std::shared_ptr<native_connection>& connection,
+                    std::vector<msgpack::object>&& fields,
+                    msgpack::zone&& zone)>;
+
+    /*!
+     * Defines a handler to be notified when the connection has been safely
+     * disconnected. This is used by the server endpoint when it initiates
+     * a disconnect with the component and receives a disconnected response
+     * from the component. Signifying that the connection can now be safely
+     * cleaned up.
+     */
+    using disconnected_handler = std::function<void()>;
+
+public:
+    native_connection(
+            boost::asio::io_service& io_service,
+            const std::shared_ptr<native_component_endpoint>& component_endpoint);
+
+    virtual ~native_connection() override;
+
+    /*!
+     * Sends a message to the component represented by a set of fields and
+     * the zone used to allocate the fields. Ownership of the fields and
+     * zone are passed to the component creating the effect of zero copy.
+     *
+     * @param fields The message fields.
+     * @param zone The zone used to allocate the message fields.
+     */
+    void send_message(
+            std::vector<msgpack::object>&& fields,
+            msgpack::zone&& zone);
+
+    /*!
+     * Retrieves the server endpoint to be used by the component to send messages
+     * to the server using this connection.
+     *
+     * @return The server endpoint using to send messages to this connection.
+     */
+    const std::shared_ptr<native_server_endpoint>& get_server_endpoint();
+
+    /*!
+     * Retrieves the component endpoint to be used by the server to send messages
+     * to the component using this connection.
+     *
+     * @return The server endpoint using to send messages to this connection.
+     */
+    const std::shared_ptr<native_component_endpoint>& get_component_endpoint() const;
+
+    const receive_message_handler& get_receive_message_handler() const;
+    void set_receive_message_handler(receive_message_handler&& handler);
+
+    const disconnected_handler& get_disconnected_handler() const;
+    void set_disconnected_handler(disconnected_handler&& handler);
+
+private:
+    /*!
+     * This io service is used to drive events for this connection.
+     */
+    boost::asio::io_service& m_io_service;
+
+    /*!
+     * The endpoint representing the server side of this connection. It is
+     * shared with the component and provides a mechanism for the component
+     * to send messages to the server using this connection.
+     */
+    std::shared_ptr<native_server_endpoint> m_server_endpoint;
+
+    /*!
+     * The endpoint representing the component side of this connection. It is
+     * passed to us by the component upon connecting and provides a mechanism
+     * for messages to be sent to the component using this connection.
+     */
+    std::shared_ptr<native_component_endpoint> m_component_endpoint;
+
+    /*!
+     * The message queue used for queuing messages sent to this connection
+     * by the component. A queue is used rather than binding functors and
+     * posting directly to the io service due to complications with binding
+     * the message zone with functors as it ends up creating move-only
+     * (non-copyable) functors. In addition, we may also want to flow control
+     * messages and using a queue allows for this to be added fairly easily.
+     */
+    native_message_queue m_receive_message_queue;
+
+    receive_message_handler m_receive_message_handler;
+    disconnected_handler m_disconnected_handler;
+};
+
+inline native_connection::native_connection(
+        boost::asio::io_service& io_service,
+        const std::shared_ptr<native_component_endpoint>& component_endpoint)
+    : wamp_connection_base()
+    , m_io_service(io_service)
+    , m_server_endpoint()
+    , m_component_endpoint(component_endpoint)
+    , m_receive_message_handler()
+    , m_disconnected_handler()
+{
+}
+
+inline native_connection::~native_connection()
+{
+}
+
+inline void native_connection::send_message(
+        std::vector<msgpack::object>&& fields,
+        msgpack::zone&& zone)
+{
+    auto send_message_handler = m_component_endpoint->get_send_message_handler();
+    send_message_handler(std::move(fields), std::move(zone));
+}
+
+inline const std::shared_ptr<native_component_endpoint>&
+native_connection::get_component_endpoint() const
+{
+    return m_component_endpoint;
+}
+
+inline const native_connection::receive_message_handler&
+native_connection::get_receive_message_handler() const
+{
+    return m_receive_message_handler;
+}
+
+inline void native_connection::set_receive_message_handler(
+        native_connection::receive_message_handler&& handler)
+{
+    m_receive_message_handler = std::move(handler);
+}
+
+inline const native_connection::disconnected_handler&
+native_connection::get_disconnected_handler() const
+{
+    return m_disconnected_handler;
+}
+
+inline void native_connection::set_disconnected_handler(
+        native_connection::disconnected_handler&& handler)
+{
+    m_disconnected_handler = std::move(handler);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_CONNECTION_HPP

--- a/src/bonefish/native/native_connector.hpp
+++ b/src/bonefish/native/native_connector.hpp
@@ -1,0 +1,124 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_CONNECTOR_HPP
+#define BONEFISH_NATIVE_CONNECTOR_HPP
+
+#include <bonefish/native/native_component_endpoint.hpp>
+#include <bonefish/native/native_server_endpoint.hpp>
+
+#include <functional>
+#include <memory>
+
+namespace bonefish {
+
+/*!
+ * A class that defines a connector that is shared between both the server
+ * and a component to allow the component to connect/disconnect. It is the
+ * server's responsibility to set the handlers in this connector and
+ * make it available to components for establishing connections. The only
+ * way a server can initiate a disconnect is through the component's endpoint
+ * as this allows the component to define how the disconnect is handled.
+ */
+class native_connector
+{
+public:
+    /*!
+     * Defines a handler used by a component to create a connection with the server.
+     * The component's endpoint is cached by the server so that it can communicate
+     * with the component. The component endpoint must be notified when the connect
+     * is complete.
+     */
+    using connect_handler =
+            std::function<void(const std::shared_ptr<native_component_endpoint>&)>;
+
+    /*!
+     * Defines a handler used by a component to disconnect from the server. The server's
+     * endpoint is passed to the handler which finds and disconnects the associated
+     * connection. The component endpoint must be notified when the disconnect is complete.
+     */
+    using disconnect_handler =
+            std::function<void(const std::shared_ptr<native_server_endpoint>&)>;
+
+public:
+    native_connector();
+
+    connect_handler get_connect_handler() const;
+    void set_connect_handler(connect_handler&& handler);
+
+    disconnect_handler get_disconnect_handler() const;
+    void set_disconnect_handler(disconnect_handler&& handler);
+
+    /*!
+     * Called by a component to create a connection with the server.
+     *
+     * @param endpoint The component endpoint that will be used to send
+     *                 messages to the component over the connection.
+     */
+    void connect(const std::shared_ptr<native_component_endpoint>& endpoint);
+
+    /*!
+     * Called by a component to disconnect a from the server.
+     *
+     * @param endpoint The server's endpoint that the component was provided
+     *                 upon a successful call to connect().
+     */
+    void disconnect(const std::shared_ptr<native_server_endpoint>& endpoint);
+
+private:
+    connect_handler m_connect_handler;
+    disconnect_handler m_disconnect_handler;
+};
+
+inline native_connector::native_connector()
+    : m_connect_handler()
+    , m_disconnect_handler()
+{
+}
+
+inline native_connector::connect_handler native_connector::get_connect_handler() const
+{
+    return m_connect_handler;
+}
+
+inline void native_connector::set_connect_handler(connect_handler&& handler)
+{
+    m_connect_handler = std::move(handler);
+}
+
+inline native_connector::disconnect_handler native_connector::get_disconnect_handler() const
+{
+    return m_disconnect_handler;
+}
+
+inline void native_connector::set_disconnect_handler(disconnect_handler&& handler)
+{
+    m_disconnect_handler = std::move(handler);
+}
+
+inline void native_connector::connect(const std::shared_ptr<native_component_endpoint>& endpoint)
+{
+    m_connect_handler(endpoint);
+}
+
+inline void native_connector::disconnect(const std::shared_ptr<native_server_endpoint>& endpoint)
+{
+    m_disconnect_handler(endpoint);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_CONNECTOR_HPP

--- a/src/bonefish/native/native_endpoint.hpp
+++ b/src/bonefish/native/native_endpoint.hpp
@@ -1,0 +1,75 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_ENDPOINT_HPP
+#define BONEFISH_NATIVE_ENDPOINT_HPP
+
+#include <functional>
+#include <msgpack.hpp>
+#include <vector>
+
+namespace bonefish {
+
+/*!
+ * A class that provides the concept of an endpoint for communicating natively
+ * between a component and a server. Communication is message based and conducted
+ * in a zero copy manner, as ownership of the message is passed via the endpoint.
+ */
+class native_endpoint
+{
+public:
+    /*!
+     * Defines a handler used by the endpoint for sending messages. The message
+     * is represented as a set of fields and the zone used to allocate them.
+     * Ownership of the fields is passed off to the recipient of the message.
+     */
+    using send_message_handler =
+            std::function<void(
+                    std::vector<msgpack::object>&& fields, msgpack::zone&& zone)>;
+
+public:
+    native_endpoint();
+
+    const send_message_handler& get_send_message_handler() const;
+    void set_send_message_handler(send_message_handler&& handler);
+
+protected:
+    ~native_endpoint() = default;
+
+private:
+    send_message_handler m_send_message_handler;
+};
+
+inline native_endpoint::native_endpoint()
+    : m_send_message_handler()
+{
+}
+
+inline const native_endpoint::send_message_handler&
+native_endpoint::get_send_message_handler() const
+{
+    return m_send_message_handler;
+}
+
+inline void native_endpoint::set_send_message_handler(
+        send_message_handler&& handler)
+{
+    m_send_message_handler = std::move(handler);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_ENDPOINT_HPP

--- a/src/bonefish/native/native_message_queue.hpp
+++ b/src/bonefish/native/native_message_queue.hpp
@@ -1,0 +1,125 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_MESSAGE_QUEUE_HPP
+#define BONEFISH_NATIVE_MESSAGE_QUEUE_HPP
+
+#include <cstddef>
+#include <deque>
+#include <msgpack.hpp>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+namespace bonefish {
+
+/*!
+ * A class that provides a queuing mechanism for native messages. Currently
+ * this is just implemented with a simple deque and a mutex. However, for
+ * better performance a lockless ring buffer can be used since there is only
+ * a single producer and single consumer. This would offer an obvious performance
+ * improvement for components with very high messaging rates. It would also then
+ * require a flow control mechanism to deal with cases where the ring buffer
+ * filled to capacity.
+ */
+class native_message_queue
+{
+public:
+    native_message_queue();
+
+    native_message_queue(const native_message_queue&) = delete;
+    native_message_queue(native_message_queue&&) = delete;
+
+    native_message_queue& operator=(const native_message_queue&) = delete;
+    native_message_queue& operator=(native_message_queue&&) = delete;
+
+    /*!
+     * Pushes a new message onto the queue.
+     */
+    void push_message(
+            std::vector<msgpack::object>&& fields,
+            msgpack::zone&& zone);
+
+    /*!
+     * Pops the next message off of the queue.
+     */
+    void pop_message(
+            std::vector<msgpack::object>& fields,
+            msgpack::zone& zone);
+
+    /*!
+     * Retrieves the size of the underlying message queue.
+     *
+     * @return The size of the underlying message queue.
+     */
+    std::size_t size() const;
+
+private:
+    /*!
+     * Defines a convenience type for a queued message entry.
+     */
+    using message = std::pair<std::vector<msgpack::object>, msgpack::zone>;
+
+private:
+    /*!
+     * Protection for access to the queue of messages.
+     */
+    std::mutex m_mutex;
+
+    /*!
+     * The queue of messages.
+     */
+    std::deque<message> m_messages;
+};
+
+inline native_message_queue::native_message_queue()
+    : m_mutex()
+    , m_messages()
+{
+}
+
+inline void native_message_queue::push_message(
+        std::vector<msgpack::object>&& fields,
+        msgpack::zone&& zone)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_messages.push_back(
+            std::move(message(std::move(fields), std::move(zone))));
+}
+
+inline void native_message_queue::pop_message(
+        std::vector<msgpack::object>& fields,
+        msgpack::zone& zone)
+{
+    if (m_messages.size() == 0) {
+        throw std::underflow_error("message queue underflow");
+    }
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto& m = m_messages.front();
+    fields = std::move(m.first);
+    zone = std::move(m.second);
+    m_messages.pop_front();
+}
+
+inline std::size_t native_message_queue::size() const
+{
+    return m_messages.size();
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_MESSAGE_QUEUE_HPP

--- a/src/bonefish/native/native_server.cpp
+++ b/src/bonefish/native/native_server.cpp
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/native/native_server.hpp>
+#include <bonefish/router/wamp_routers.hpp>
+#include <bonefish/serialization/wamp_serializers.hpp>
+#include <bonefish/native/native_server_impl.hpp>
+
+namespace bonefish {
+
+native_server::native_server(
+        boost::asio::io_service& io_service,
+        const std::shared_ptr<wamp_routers>& routers)
+    : m_impl(new native_server_impl(io_service, routers))
+{
+}
+
+native_server::~native_server()
+{
+}
+
+std::shared_ptr<native_connector> native_server::get_connector() const
+{
+    return m_impl->get_connector();
+}
+
+void native_server::start()
+{
+    m_impl->start();
+}
+
+void native_server::shutdown()
+{
+    m_impl->shutdown();
+}
+
+} // namespace bonefish

--- a/src/bonefish/native/native_server.hpp
+++ b/src/bonefish/native/native_server.hpp
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_SERVER_HPP
+#define BONEFISH_NATIVE_SERVER_HPP
+
+#include <boost/asio/io_service.hpp>
+#include <memory>
+
+namespace bonefish {
+
+class native_connector;
+class native_server_impl;
+class wamp_routers;
+
+/*!
+ * A class that provides a synthesized server designed to allow for native
+ * transports to be utilized. Native transports allow for an in process
+ * mechanism for components to connect and perform all manner of WAMP
+ * operations without the need for sockets or any other type of IPC
+ * mechanism.
+ */
+class native_server
+{
+public:
+    native_server(
+            boost::asio::io_service& io_service,
+            const std::shared_ptr<wamp_routers>& routers);
+
+    ~native_server();
+
+    /*!
+     * Retrieves the connector that components can use to connect to the server.
+     *
+     * @return The connector that components can use to connect to the server.
+     */
+    std::shared_ptr<native_connector> get_connector() const;
+
+    /*!
+     * Starts the server.
+     */
+    void start();
+
+    /*!
+     * Shuts down the server.
+     */
+    void shutdown();
+
+private:
+    /*!
+     * The underlying server implementation.
+     */
+    std::shared_ptr<native_server_impl> m_impl;
+};
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_SERVER_HPP

--- a/src/bonefish/native/native_server_endpoint.hpp
+++ b/src/bonefish/native/native_server_endpoint.hpp
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_SERVER_ENDPOINT_HPP
+#define BONEFISH_NATIVE_SERVER_ENDPOINT_HPP
+
+#include <bonefish/native/native_endpoint.hpp>
+#include <functional>
+#include <memory>
+
+namespace bonefish {
+
+/*!
+ * A class that provides the concept of an endpoint for communicating natively
+ * with a server. Components initiate connections with the server utilizing the
+ * connector provided by the server. Components can also use the connector to
+ * disconnect from the server. However, all the server gets access to when
+ * connections are created is a component's endpoint. As a result if it wants
+ * to initiate a disconnect with a component it can only do so by using the
+ * component's endpoint. When a server initiates a disconnect it must synchronize
+ * with the component to ensure that any shared state can be safely destroyed.
+ * As a result, a server endpoint must provide a handler to be invoked by the
+ * component when a disconnect issued by the server has been processed.
+ */
+class native_server_endpoint :
+        public native_endpoint,
+        public std::enable_shared_from_this<native_server_endpoint>
+{
+public:
+    /*!
+     * Defines a handler to be invoked by the component to indicate when a server
+     * initiated disconnect is complete.
+     */
+    using disconnected_handler = std::function<void()>;
+
+public:
+    native_server_endpoint();
+
+    const disconnected_handler& get_disconnected_handler() const;
+    void set_disconnected_handler(disconnected_handler&& handler);
+
+private:
+    disconnected_handler m_disconnected_handler;
+};
+
+inline native_server_endpoint::native_server_endpoint()
+    : m_disconnected_handler()
+{
+}
+
+inline const native_server_endpoint::disconnected_handler&
+native_server_endpoint::get_disconnected_handler() const
+{
+    return m_disconnected_handler;
+}
+
+inline void native_server_endpoint::set_disconnected_handler(
+        disconnected_handler&& handler)
+{
+    m_disconnected_handler = handler;
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_SERVER_ENDPOINT_HPP

--- a/src/bonefish/native/native_server_impl.cpp
+++ b/src/bonefish/native/native_server_impl.cpp
@@ -1,0 +1,182 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/native/native_server_impl.hpp>
+#include <bonefish/messages/wamp_message.hpp>
+#include <bonefish/messages/wamp_message_factory.hpp>
+#include <bonefish/native/native_component_endpoint.hpp>
+#include <bonefish/native/native_connection.hpp>
+#include <bonefish/native/native_connector.hpp>
+#include <bonefish/native/native_server_endpoint.hpp>
+#include <bonefish/native/native_transport.hpp>
+#include <bonefish/router/wamp_router.hpp>
+#include <bonefish/router/wamp_routers.hpp>
+#include <bonefish/serialization/wamp_serializer.hpp>
+#include <bonefish/serialization/wamp_serializers.hpp>
+#include <bonefish/transport/wamp_transport.hpp>
+#include <bonefish/trace/trace.hpp>
+
+#include <stdexcept>
+
+namespace bonefish {
+
+native_server_impl::native_server_impl(
+        boost::asio::io_service& io_service,
+        const std::shared_ptr<wamp_routers>& routers)
+    : m_io_service(io_service)
+    , m_routers(routers)
+    , m_connector(std::make_shared<native_connector>())
+    , m_connections()
+    , m_endpoints_connected()
+    , m_message_processor(routers)
+{
+    std::weak_ptr<native_server_impl> weak_this = shared_from_this();
+
+    auto connect_handler = [this, weak_this](
+            const std::shared_ptr<native_component_endpoint>& component_endpoint) {
+        auto shared_this = weak_this.lock();
+        if (!shared_this) {
+            // Will be thrown in the context of the component
+            throw std::runtime_error("connect failed");
+        }
+        auto server_endpoint = on_connect(component_endpoint);
+        auto connected_handler = component_endpoint->get_connected_handler();
+        connected_handler(server_endpoint);
+    };
+    m_connector->set_connect_handler(connect_handler);
+
+    auto disconnect_handler = [this, weak_this](
+            const std::shared_ptr<native_server_endpoint>& server_endpoint) {
+        auto shared_this = weak_this.lock();
+        if (shared_this) {
+            // Will be thrown in the context of the component
+            throw std::runtime_error("disconnect failed");
+        }
+        auto component_endpoint = on_disconnect(server_endpoint);
+        auto disconnected_handler = component_endpoint->get_disconnected_handler();
+        disconnected_handler();
+    };
+    m_connector->set_disconnect_handler(disconnect_handler);
+}
+
+native_server_impl::~native_server_impl()
+{
+}
+
+void native_server_impl::start()
+{
+    BONEFISH_TRACE("starting native server");
+}
+
+void native_server_impl::shutdown()
+{
+    BONEFISH_TRACE("stopping native server");
+    // FIXME: Walk all of the connections and disconnect them?
+}
+
+std::shared_ptr<native_server_endpoint> native_server_impl::on_connect(
+        const std::shared_ptr<native_component_endpoint>& component_endpoint)
+{
+    auto connection = std::make_shared<native_connection>(
+            m_io_service, component_endpoint);
+    std::weak_ptr<native_server_impl> weak_this = shared_from_this();
+
+    auto receive_handler = [this, weak_this](
+            const std::shared_ptr<native_connection>& connection,
+            std::vector<msgpack::object>&& fields,
+            msgpack::zone&& zone) {
+        auto shared_this = weak_this.lock();
+        if (!shared_this) {
+            // There is nothing to do here but silently dismiss this
+            // error condition. If the server or connection has gone
+            // away then the message being recevied is meaningless.
+            return;
+        }
+
+        on_message(connection, std::move(fields), std::move(zone));
+    };
+    connection->set_receive_message_handler(
+            std::bind(receive_handler, std::placeholders::_1,
+                    std::placeholders::_2, std::placeholders::_3));
+
+    auto server_endpoint = connection->get_server_endpoint();
+    auto disconnected_handler = [this, weak_this](
+            const std::shared_ptr<native_server_endpoint>& server_endpoint) {
+        auto shared_this = weak_this.lock();
+        if (!shared_this) {
+            // There is nothing to do here but silently dismiss this
+            // error condition. The server has gone away which means
+            // the message we are trying to deliver is meaningless.
+            return;
+        }
+        on_disconnect(server_endpoint);
+    };
+    connection->set_disconnected_handler(std::bind(disconnected_handler, server_endpoint));
+
+    m_connections.insert(connection);
+    m_endpoints_connected[server_endpoint] = connection;
+
+    return server_endpoint;
+}
+
+std::shared_ptr<native_component_endpoint> native_server_impl::on_disconnect(
+        const std::shared_ptr<native_server_endpoint>& server_endpoint)
+{
+    auto itr = m_endpoints_connected.find(server_endpoint);
+    if (itr == m_endpoints_connected.end()) {
+        std::invalid_argument("server endpoint does not exist");
+    }
+
+    auto connection = itr->second;
+    if (connection->has_session_id()) {
+        std::shared_ptr<wamp_router> router =
+                m_routers->get_router(connection->get_realm());
+        if (router) {
+            router->detach_session(connection->get_session_id());
+        }
+    }
+
+    m_endpoints_connected.erase(itr);
+    m_connections.erase(connection);
+
+    return connection->get_component_endpoint();
+}
+
+void native_server_impl::on_message(
+        const std::shared_ptr<native_connection>& connection,
+        const std::vector<msgpack::object>& fields,
+        msgpack::zone&& zone)
+{
+    try {
+        if (fields.size() < 1) {
+            throw std::runtime_error("invalid message");
+        }
+
+        auto type = static_cast<wamp_message_type>(fields[0].as<unsigned>());
+        std::unique_ptr<wamp_message> message(wamp_message_factory::create_message(type));
+        if (!message) {
+            throw std::runtime_error("message type not supported");
+        }
+        message->unmarshal(fields, std::move(zone));
+
+        std::unique_ptr<wamp_transport> transport(new native_transport(connection));
+        m_message_processor.process_message(message, std::move(transport), connection.get());
+    } catch (const std::exception& e) {
+        BONEFISH_TRACE("unhandled exception: %1%", e.what());
+    }
+}
+
+} // namespace bonefish

--- a/src/bonefish/native/native_server_impl.hpp
+++ b/src/bonefish/native/native_server_impl.hpp
@@ -1,0 +1,144 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_NATIVE_SERVER_IMPL_HPP
+#define BONEFISH_NATIVE_SERVER_IMPL_HPP
+
+#include <bonefish/common/wamp_message_processor.hpp>
+#include <bonefish/native/native_connector.hpp>
+
+#include <boost/asio/io_service.hpp>
+#include <map>
+#include <memory>
+#include <msgpack.hpp>
+#include <set>
+#include <vector>
+
+namespace bonefish {
+
+class native_component_endpoint;
+class native_connection;
+class native_server_endpoint;
+class wamp_routers;
+
+/*!
+ * A class representing the implementation of a native server.
+ */
+class native_server_impl :
+        public std::enable_shared_from_this<native_server_impl>
+{
+public:
+    native_server_impl(
+            boost::asio::io_service& io_service,
+            const std::shared_ptr<wamp_routers>& routers);
+
+    ~native_server_impl();
+
+    /*!
+     * Retrieves the connector that components can use to connect to the server.
+     *
+     * @return The connector that components can use to connect to the server.
+     */
+    std::shared_ptr<native_connector> get_connector() const;
+
+    /*!
+     * Starts the server.
+     */
+    void start();
+
+    /*!
+     * Shuts down the server.
+     */
+    void shutdown();
+
+private:
+    /*!
+     * Callback handler that is invoked when a component is establishing a
+     * connection with the server.
+     *
+     * @param component_endpoint The endpoint of the component that is establishing
+     *                           the connection.
+     */
+    std::shared_ptr<native_server_endpoint> on_connect(
+            const std::shared_ptr<native_component_endpoint>& component_endpoint);
+
+    /*!
+     * Callback handler that is invoked when a component is establishing a
+     * connection with the server.
+     *
+     * @param component_endpoint The endpoint of the component that is establishing
+     *                           the connection.
+     */
+    std::shared_ptr<native_component_endpoint> on_disconnect(
+            const std::shared_ptr<native_server_endpoint>& endpoint);
+
+    /*!
+     * Callback handler that is invoked when a message has been received.
+     *
+     * @param connection The connection that the message arrived on.
+     * @param fields The fields representing the message.
+     * @param zone The zone the message fields were allocated from.
+     */
+    void on_message(
+            const std::shared_ptr<native_connection>& connection,
+            const std::vector<msgpack::object>& fields,
+            msgpack::zone&& zone);
+
+private:
+    /*!
+     * The io service to drive all events.
+     */
+    boost::asio::io_service& m_io_service;
+
+    /*!
+     * The routers serviced by this server.
+     */
+    std::shared_ptr<wamp_routers> m_routers;
+
+    /*!
+     * The connector that components can use to connect to this server.
+     */
+    std::shared_ptr<native_connector> m_connector;
+
+    /*!
+     * The current set of active connections.
+     */
+    std::set<std::shared_ptr<native_connection>,
+            std::owner_less<std::shared_ptr<native_connection>>> m_connections;
+
+    /*!
+     * A mapping of server endpoints to connections. Components only know
+     * about server endpoints so this allows us to perform the reverse mapping
+     * when required.
+     */
+    std::map<std::shared_ptr<native_server_endpoint>,
+            std::shared_ptr<native_connection>,
+            std::owner_less<std::shared_ptr<native_server_endpoint>>> m_endpoints_connected;
+
+    /*!
+     * The message processor to use for feeding messages into the routers.
+     */
+    wamp_message_processor m_message_processor;
+};
+
+inline std::shared_ptr<native_connector> native_server_impl::get_connector() const
+{
+    return m_connector;
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_NATIVE_SERVER_IMPL_HPP

--- a/src/bonefish/native/native_transport.hpp
+++ b/src/bonefish/native/native_transport.hpp
@@ -14,34 +14,41 @@
  *  limitations under the License.
  */
 
-#ifndef BONEFISH_RAWSOCKET_TRANSPORT_HPP
-#define BONEFISH_RAWSOCKET_TRANSPORT_HPP
+#ifndef BONEFISH_NATIVE_TRANSPORT_HPP
+#define BONEFISH_NATIVE_TRANSPORT_HPP
 
 #include <bonefish/transport/wamp_transport.hpp>
 
-#include <iostream>
 #include <memory>
 
 namespace bonefish {
 
-class rawsocket_connection;
+class native_connection;
 class wamp_message;
-class wamp_serializer;
 
-class rawsocket_transport : public wamp_transport
+/*!
+ * A class that provides a transport that can be used to send messages
+ * over an underlying connection.
+ */
+class native_transport : public wamp_transport
 {
 public:
-    rawsocket_transport(
-            const std::shared_ptr<wamp_serializer>& serializer,
-            const std::shared_ptr<rawsocket_connection>& connection);
+    native_transport(const std::shared_ptr<native_connection>& connection);
 
+    /*!
+     * Sends a message over the transports connection.
+     *
+     * @param message The WAMP message to send.
+     */
     virtual bool send_message(wamp_message&& message) override;
 
 private:
-    std::shared_ptr<wamp_serializer> m_serializer;
-    std::shared_ptr<rawsocket_connection> m_connection;
+    /*!
+     * The underlying connection for sending messages.
+     */
+    std::shared_ptr<native_connection> m_connection;
 };
 
 } // namespace bonefish
 
-#endif // BONEFISH_RAWSOCKET_TRANSPORT_HPP
+#endif // BONEFISH_NATIVE_TRANSPORT_HPP

--- a/src/bonefish/rawsocket/rawsocket_server_impl.cpp
+++ b/src/bonefish/rawsocket/rawsocket_server_impl.cpp
@@ -17,6 +17,7 @@
 #include <bonefish/rawsocket/rawsocket_server_impl.hpp>
 #include <bonefish/identifiers/wamp_session_id.hpp>
 #include <bonefish/identifiers/wamp_session_id_generator.hpp>
+#include <bonefish/messages/wamp_message.hpp>
 #include <bonefish/router/wamp_router.hpp>
 #include <bonefish/router/wamp_routers.hpp>
 #include <bonefish/rawsocket/rawsocket_listener.hpp>

--- a/src/bonefish/rawsocket/rawsocket_transport.cpp
+++ b/src/bonefish/rawsocket/rawsocket_transport.cpp
@@ -34,9 +34,9 @@ rawsocket_transport::rawsocket_transport(
 {
 }
 
-bool rawsocket_transport::send_message(const wamp_message* message)
+bool rawsocket_transport::send_message(wamp_message&& message)
 {
-    BONEFISH_TRACE("sending message: %1%", message_type_to_string(message->get_type()));
+    BONEFISH_TRACE("sending message: %1%", message_type_to_string(message.get_type()));
     expandable_buffer buffer = m_serializer->serialize(message);
     return m_connection->send_message(buffer.data(), buffer.size());
 }

--- a/src/bonefish/router/wamp_router_impl.cpp
+++ b/src/bonefish/router/wamp_router_impl.cpp
@@ -182,7 +182,7 @@ void wamp_router_impl::process_hello_message(const wamp_session_id& session_id,
 
     std::unique_ptr<wamp_welcome_message> welcome_message(new wamp_welcome_message);
     welcome_message->set_session_id(session_id);
-    welcome_message->set_details(m_welcome_details.marshal());
+    welcome_message->set_details(m_welcome_details.marshal(welcome_message->get_zone()));
 
     // If we fail to send the welcome message it is most likely that the
     // underlying network connection has been closed/lost which means

--- a/src/bonefish/router/wamp_router_impl.cpp
+++ b/src/bonefish/router/wamp_router_impl.cpp
@@ -98,7 +98,7 @@ void wamp_router_impl::close_session(const wamp_session_id& session_id, const st
         session->set_state(wamp_session_state::CLOSING);
 
         BONEFISH_TRACE("%1%, %2%", *session % *goodbye_message);
-        session->get_transport()->send_message(goodbye_message.get());
+        session->get_transport()->send_message(std::move(*goodbye_message));
     }
 }
 
@@ -165,7 +165,7 @@ void wamp_router_impl::process_hello_message(const wamp_session_id& session_id,
         std::unique_ptr<wamp_abort_message> abort_message(new wamp_abort_message);
         abort_message->set_reason("wamp.error.session_already_open");
         BONEFISH_TRACE("%1%, %2%", *session % *abort_message);
-        session->get_transport()->send_message(abort_message.get());
+        session->get_transport()->send_message(std::move(*abort_message));
         return;
     }
 
@@ -174,7 +174,7 @@ void wamp_router_impl::process_hello_message(const wamp_session_id& session_id,
         std::unique_ptr<wamp_abort_message> abort_message(new wamp_abort_message);
         abort_message->set_reason("wamp.error.invalid_roles");
         BONEFISH_TRACE("%1%, %2%", *session % *abort_message);
-        session->get_transport()->send_message(abort_message.get());
+        session->get_transport()->send_message(std::move(*abort_message));
         return;
     }
 
@@ -189,7 +189,7 @@ void wamp_router_impl::process_hello_message(const wamp_session_id& session_id,
     // that the component is no longer reachable on this session. So all
     // we do here is trace the fact that this event occured.
     BONEFISH_TRACE("%1%, %2%", *session % *welcome_message);
-    if (!session->get_transport()->send_message(welcome_message.get())) {
+    if (!session->get_transport()->send_message(std::move(*welcome_message))) {
         BONEFISH_TRACE("failed to send the welcome message: network failure");
     }
 }
@@ -209,7 +209,7 @@ void wamp_router_impl::process_goodbye_message(const wamp_session_id& session_id
         session->set_state(wamp_session_state::CLOSED);
 
         BONEFISH_TRACE("%1%, %2%", *session % *goodbye_message);
-        if (!session->get_transport()->send_message(message.get())) {
+        if (!session->get_transport()->send_message(std::move(*message))) {
             BONEFISH_TRACE("failed to send goodbye message to component: network failure");
         }
     } else if (session->get_state() == wamp_session_state::CLOSING) {

--- a/src/bonefish/serialization/json_msgpack_sax.hpp
+++ b/src/bonefish/serialization/json_msgpack_sax.hpp
@@ -27,8 +27,10 @@
 #ifndef BONEFISH_SERIALIZATION_JSON_MSGPACK_SAX_HPP
 #define BONEFISH_SERIALIZATION_JSON_MSGPACK_SAX_HPP
 
+#include <cstddef>
 #include <msgpack.hpp>
 #include <stack>
+#include <vector>
 
 namespace bonefish {
 namespace serialization {
@@ -283,7 +285,7 @@ struct msgpack_from_json_handler
     }
 
 private:
-    std::stack<size_t> m_container_indexes;
+    std::stack<std::size_t> m_container_indexes;
     std::vector<msgpack::object> m_queued;
     msgpack::object& m_root;
     msgpack::zone& m_zone;

--- a/src/bonefish/serialization/json_serializer.cpp
+++ b/src/bonefish/serialization/json_serializer.cpp
@@ -167,8 +167,8 @@ struct wamp_bin_string_conversion
 
 wamp_message* json_serializer::deserialize(const char* buffer, size_t length) const
 {
-    msgpack::zone zone;
     msgpack::object item;
+    msgpack::zone zone;
 
     imemstream bufferstream(buffer, length);
     serialization::msgpack_from_json_handler<wamp_bin_string_conversion> handler(item, zone);
@@ -187,7 +187,7 @@ wamp_message* json_serializer::deserialize(const char* buffer, size_t length) co
     wamp_message_type type = static_cast<wamp_message_type>(fields[0].as<unsigned>());
     std::unique_ptr<wamp_message> message(wamp_message_factory::create_message(type));
     if (message) {
-        message->unmarshal(fields);
+        message->unmarshal(fields, std::move(zone));
     } else {
         throw std::runtime_error("no deserializer defined for message");
     }

--- a/src/bonefish/serialization/json_serializer.cpp
+++ b/src/bonefish/serialization/json_serializer.cpp
@@ -195,13 +195,13 @@ wamp_message* json_serializer::deserialize(const char* buffer, size_t length) co
     return message.release();
 }
 
-expandable_buffer json_serializer::serialize(const wamp_message* message) const
+expandable_buffer json_serializer::serialize(const wamp_message& message) const
 {
     expandable_buffer buffer(10*1024);
     omemstream bufferstream(buffer);
     rapidjson::Writer<omemstream> writer(bufferstream);
 
-    const std::vector<msgpack::object>& fields = message->marshal();
+    const std::vector<msgpack::object>& fields = message.marshal();
     bool write_failed = false;
 
     do {

--- a/src/bonefish/serialization/json_serializer.hpp
+++ b/src/bonefish/serialization/json_serializer.hpp
@@ -34,7 +34,7 @@ public:
 
     virtual wamp_serializer_type get_type() const override;
     virtual wamp_message* deserialize(const char* buffer, size_t length) const override;
-    virtual expandable_buffer serialize(const wamp_message* message) const override;
+    virtual expandable_buffer serialize(const wamp_message& message) const override;
 };
 
 inline json_serializer::json_serializer()

--- a/src/bonefish/serialization/msgpack_serializer.cpp
+++ b/src/bonefish/serialization/msgpack_serializer.cpp
@@ -51,7 +51,7 @@ wamp_message* msgpack_serializer::deserialize(const char* buffer, size_t length)
     wamp_message_type type = static_cast<wamp_message_type>(fields[0].as<unsigned>());
     std::unique_ptr<wamp_message> message(wamp_message_factory::create_message(type));
     if (message) {
-        message->unmarshal(fields);
+        message->unmarshal(fields, std::move(*(item.zone())));
     } else {
         throw std::runtime_error("no deserializer defined for message");
     }

--- a/src/bonefish/serialization/msgpack_serializer.cpp
+++ b/src/bonefish/serialization/msgpack_serializer.cpp
@@ -59,11 +59,11 @@ wamp_message* msgpack_serializer::deserialize(const char* buffer, size_t length)
     return message.release();
 }
 
-expandable_buffer msgpack_serializer::serialize(const wamp_message* message) const
+expandable_buffer msgpack_serializer::serialize(const wamp_message& message) const
 {
     expandable_buffer buffer(10*1024);
     msgpack::packer<expandable_buffer> packer(buffer);
-    packer.pack(message->marshal());
+    packer.pack(message.marshal());
 
     return buffer;
 }

--- a/src/bonefish/serialization/msgpack_serializer.hpp
+++ b/src/bonefish/serialization/msgpack_serializer.hpp
@@ -34,7 +34,7 @@ public:
 
     virtual wamp_serializer_type get_type() const override;
     virtual wamp_message* deserialize(const char* buffer, size_t length) const override;
-    virtual expandable_buffer serialize(const wamp_message* message) const override;
+    virtual expandable_buffer serialize(const wamp_message& message) const override;
 };
 
 inline msgpack_serializer::msgpack_serializer()

--- a/src/bonefish/serialization/wamp_serializer.hpp
+++ b/src/bonefish/serialization/wamp_serializer.hpp
@@ -36,7 +36,7 @@ public:
 
     virtual wamp_serializer_type get_type() const = 0;
     virtual wamp_message* deserialize(const char* buffer, size_t length) const = 0;
-    virtual expandable_buffer serialize(const wamp_message* message) const = 0;
+    virtual expandable_buffer serialize(const wamp_message& message) const = 0;
 };
 
 inline wamp_serializer::wamp_serializer()

--- a/src/bonefish/transport/wamp_transport.hpp
+++ b/src/bonefish/transport/wamp_transport.hpp
@@ -17,13 +17,6 @@
 #ifndef BONEFISH_TRANSPORT_WAMP_TRANSPORT_HPP
 #define BONEFISH_TRANSPORT_WAMP_TRANSPORT_HPP
 
-#include <bonefish/messages/wamp_message.hpp>
-#include <bonefish/serialization/wamp_serializer.hpp>
-
-#include <memory>
-#include <websocketpp/common/connection_hdl.hpp>
-#include <websocketpp/server.hpp>
-
 namespace bonefish {
 
 class wamp_message;
@@ -31,18 +24,9 @@ class wamp_message;
 class wamp_transport
 {
 public:
-    wamp_transport();
-    virtual ~wamp_transport();
-    virtual bool send_message(const wamp_message* message) = 0;
+    virtual ~wamp_transport() = default;
+    virtual bool send_message(wamp_message&& message) = 0;
 };
-
-inline wamp_transport::wamp_transport()
-{
-}
-
-inline wamp_transport::~wamp_transport()
-{
-}
 
 } // namespace bonefish
 

--- a/src/bonefish/websocket/websocket_server_impl.cpp
+++ b/src/bonefish/websocket/websocket_server_impl.cpp
@@ -17,6 +17,7 @@
 #include <bonefish/websocket/websocket_server_impl.hpp>
 #include <bonefish/identifiers/wamp_session_id.hpp>
 #include <bonefish/identifiers/wamp_session_id_generator.hpp>
+#include <bonefish/messages/wamp_message.hpp>
 #include <bonefish/router/wamp_router.hpp>
 #include <bonefish/router/wamp_routers.hpp>
 #include <bonefish/serialization/wamp_serializer.hpp>

--- a/src/bonefish/websocket/websocket_transport.hpp
+++ b/src/bonefish/websocket/websocket_transport.hpp
@@ -36,7 +36,7 @@ public:
             const websocketpp::connection_hdl& handle,
             const std::shared_ptr<websocketpp::server<websocket_config>>& server);
 
-    virtual bool send_message(const wamp_message* message) override;
+    virtual bool send_message(wamp_message&& message) override;
 
 private:
     std::shared_ptr<wamp_serializer> m_serializer;


### PR DESCRIPTION
This commit converts all messages to use shallow copy semantics
for unmarshalling msgpack objects rather than deep copying each
object.
