### PR TITLE
Make rawsocket listening sockets more resilient

### DIFF
--- a/src/bonefish/rawsocket/tcp_listener.cpp
+++ b/src/bonefish/rawsocket/tcp_listener.cpp
@@ -37,6 +37,9 @@ tcp_listener::~tcp_listener()
 
 void tcp_listener::start_listening()
 {
+    assert(get_error_handler());
+    assert(get_accept_handler());
+
     if (is_listening()) {
         return;
     }
@@ -48,7 +51,6 @@ void tcp_listener::start_listening()
     m_acceptor.listen();
 
     set_listening(true);
-    assert(get_accept_handler());
     async_accept();
 }
 

--- a/src/bonefish/rawsocket/uds_listener.cpp
+++ b/src/bonefish/rawsocket/uds_listener.cpp
@@ -38,6 +38,9 @@ uds_listener::~uds_listener()
 
 void uds_listener::start_listening()
 {
+    assert(get_error_handler());
+    assert(get_accept_handler());
+
     if (is_listening()) {
         return;
     }
@@ -49,7 +52,6 @@ void uds_listener::start_listening()
     m_acceptor.bind(m_endpoint);
     m_acceptor.listen();
 
-    assert(get_accept_handler());
     set_listening(true);
     async_accept();
 }


### PR DESCRIPTION
This commit adds some error handling to make rawsocket
listening sockets to be more resilient to network errors.
This prevents listening socket from being rendered useless
by re-establishing the listening socket in the event of
an error.
