### PR TITLE
Adjusting WAMP Sequential ID Range for Autobahn Example

### DIFF
--- a/src/bonefish/identifiers/wamp_sequential_id.hpp
+++ b/src/bonefish/identifiers/wamp_sequential_id.hpp
@@ -29,7 +29,7 @@ namespace bonefish {
 class wamp_sequential_id
 {
 public:
-    static const uint64_t MIN = 1;
+    static const uint64_t MIN = 0;
     static const uint64_t MAX = 1ULL << 53;
 #if defined(_MSC_VER)
     static const uint64_t INVALID = UINT64_MAX;
@@ -58,7 +58,7 @@ inline wamp_sequential_id::wamp_sequential_id()
 inline wamp_sequential_id::wamp_sequential_id(uint64_t id)
     : m_id(id)
 {
-    if (m_id < MIN || m_id > MAX) {
+    if (m_id > MAX) {
         std::stringstream ss;
         ss << "sequential id " << m_id << " is out of range";
         throw std::invalid_argument(ss.str());


### PR DESCRIPTION
When trying to run the Autobahn|Python "arguments" example [listed here](https://github.com/crossbario/autobahn-python/tree/master/examples/twisted/wamp/rpc/arguments) I encountered the error:

```
[wamp_message_processor.cpp:46][process_message] processing message: register
[wamp_dealer.cpp:289][process_register_message] [websocket_server_impl.cpp:221][on_message] unhandled exception: sequential id 0 is out of range
```

when trying to launch the python backend.

This PR "fixes" it by expanding the valid id range to include 0 and disables the lower bounds checking (because the compiler was complaining about that conditional always being true).

I haven't even attempted any C++ in about a decade so definitely let me know if I've done something horribly wrong here, and i'll do my best to fix it.

This was done on Mac OS X 10.9, using `autobahn==0.10.9` with boost installed via macports.  Building bonefish required specifying full paths to a couple boost libs that were supplied as `.dylib` files (in case anyone else was having trouble in that config).
