### PR TITLE
Add support for progressive call results

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,12 @@ The advanced profile is fairly extensive and is very feature based. There will b
 <tr>
 <td>Remote Procedure Calls</td>
 <td>Call Timeouts</td>
-<td>Allows calls to specify a timeout. The default is never timeout.</td>
+<td>Allows callers to specify a timeout. The default is never timeout.</td>
+</tr>
+<tr>
+<td></td>
+<td>Progressive Call Results</td>
+<td>Allows callers to specify that they support receiving results that span across multiple yields from the callee. These multi-part style results are guaranteed to arrive in order.</td>
 </tr>
 </table>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,13 @@ set(SOURCES
     bonefish/identifiers/wamp_session_id_factory.cpp
     bonefish/messages/wamp_call_options.cpp
     bonefish/messages/wamp_hello_details.cpp
+    bonefish/messages/wamp_invocation_details.cpp
     bonefish/messages/wamp_message_defaults.cpp
     bonefish/messages/wamp_message_factory.cpp
     bonefish/messages/wamp_message_type.cpp
+    bonefish/messages/wamp_result_details.cpp
     bonefish/messages/wamp_welcome_details.cpp
+    bonefish/messages/wamp_yield_options.cpp
     bonefish/native/native_connection.cpp
     bonefish/native/native_server.cpp
     bonefish/native/native_server_impl.cpp
@@ -83,6 +86,7 @@ set(PRIVATE_HEADERS
     bonefish/messages/wamp_goodbye_message.hpp
     bonefish/messages/wamp_hello_details.hpp
     bonefish/messages/wamp_hello_message.hpp
+    bonefish/messages/wamp_invocation_details.hpp
     bonefish/messages/wamp_invocation_message.hpp
     bonefish/messages/wamp_message.hpp
     bonefish/messages/wamp_message_defaults.hpp
@@ -92,6 +96,7 @@ set(PRIVATE_HEADERS
     bonefish/messages/wamp_published_message.hpp
     bonefish/messages/wamp_registered_message.hpp
     bonefish/messages/wamp_register_message.hpp
+    bonefish/messages/wamp_result_details.hpp
     bonefish/messages/wamp_result_message.hpp
     bonefish/messages/wamp_subscribed_message.hpp
     bonefish/messages/wamp_subscribe_message.hpp
@@ -102,6 +107,7 @@ set(PRIVATE_HEADERS
     bonefish/messages/wamp_welcome_details.hpp
     bonefish/messages/wamp_welcome_message.hpp
     bonefish/messages/wamp_yield_message.hpp
+    bonefish/messages/wamp_yield_options.hpp
     bonefish/native/native_connection.hpp
     bonefish/native/native_server_impl.hpp
     bonefish/native/native_transport.hpp

--- a/src/bonefish/messages/wamp_call_message.hpp
+++ b/src/bonefish/messages/wamp_call_message.hpp
@@ -185,7 +185,7 @@ inline void wamp_call_message::set_options(const msgpack::object& options)
 
 inline void wamp_call_message::set_procedure(const std::string& procedure)
 {
-    m_procedure = procedure;
+    m_procedure = msgpack::object(procedure, get_zone());
 }
 
 inline void wamp_call_message::set_arguments(const msgpack::object& arguments)

--- a/src/bonefish/messages/wamp_invocation_details.cpp
+++ b/src/bonefish/messages/wamp_invocation_details.cpp
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/messages/wamp_invocation_details.hpp>
+
+#include <stdexcept>
+
+namespace bonefish {
+
+msgpack::object wamp_invocation_details::marshal(msgpack::zone& zone) const
+{
+    return msgpack::object(m_details, zone);
+}
+
+void wamp_invocation_details::unmarshal(const msgpack::object& object)
+{
+    object.convert(m_details);
+}
+
+} // namespace bonefish

--- a/src/bonefish/messages/wamp_invocation_details.hpp
+++ b/src/bonefish/messages/wamp_invocation_details.hpp
@@ -1,0 +1,89 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_MESSAGES_WAMP_INVOCATION_DETAILS_HPP
+#define BONEFISH_MESSAGES_WAMP_INVOCATION_DETAILS_HPP
+
+#include <map>
+#include <msgpack.hpp>
+#include <string>
+
+namespace bonefish {
+
+class wamp_invocation_details
+{
+public:
+    wamp_invocation_details();
+    virtual ~wamp_invocation_details();
+
+    msgpack::object marshal(msgpack::zone& zone) const;
+    void unmarshal(const msgpack::object& details);
+
+    template <typename T>
+    T get_detail(const std::string& name) const;
+
+    template <typename T>
+    T get_detail_or(const std::string& name, const T& default_value) const;
+
+    template <typename T>
+    void set_detail(const std::string& name, const T& value);
+
+private:
+    msgpack::zone m_zone;
+    std::map<std::string, msgpack::object> m_details;
+};
+
+inline wamp_invocation_details::wamp_invocation_details()
+    : m_zone()
+    , m_details()
+{
+}
+
+inline wamp_invocation_details::~wamp_invocation_details()
+{
+}
+
+template <typename T>
+T wamp_invocation_details::get_detail(const std::string& name) const
+{
+    const auto detail_itr = m_details.find(name);
+    if (detail_itr == m_details.end()) {
+        throw std::invalid_argument("invalid detail requested: " + name);
+    }
+
+    return detail_itr->second.as<T>();
+}
+
+template <typename T>
+T wamp_invocation_details::get_detail_or(const std::string& name, const T& default_value) const
+{
+    const auto detail_itr = m_details.find(name);
+    if (detail_itr == m_details.end()) {
+        return default_value;
+    }
+
+    return detail_itr->second.as<T>();
+}
+
+template <typename T>
+void wamp_invocation_details::set_detail(const std::string& name, const T& value)
+{
+    m_details[name] = msgpack::object(value, m_zone);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_MESSAGES_WAMP_INVOCATION_DETAILS_HPP

--- a/src/bonefish/messages/wamp_result_details.cpp
+++ b/src/bonefish/messages/wamp_result_details.cpp
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/messages/wamp_result_details.hpp>
+
+#include <stdexcept>
+
+namespace bonefish {
+
+msgpack::object wamp_result_details::marshal(msgpack::zone& zone) const
+{
+    return msgpack::object(m_details, zone);
+}
+
+void wamp_result_details::unmarshal(const msgpack::object& object)
+{
+    object.convert(m_details);
+}
+
+} // namespace bonefish

--- a/src/bonefish/messages/wamp_result_details.hpp
+++ b/src/bonefish/messages/wamp_result_details.hpp
@@ -1,0 +1,89 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_MESSAGES_WAMP_RESULT_DETAILS_HPP
+#define BONEFISH_MESSAGES_WAMP_RESULT_DETAILS_HPP
+
+#include <msgpack.hpp>
+#include <string>
+#include <map>
+
+namespace bonefish {
+
+class wamp_result_details
+{
+public:
+    wamp_result_details();
+    virtual ~wamp_result_details();
+
+    msgpack::object marshal(msgpack::zone& zone) const;
+    void unmarshal(const msgpack::object& details);
+
+    template <typename T>
+    T get_detail(const std::string& name) const;
+
+    template <typename T>
+    T get_detail_or(const std::string& name, const T& default_value) const;
+
+    template <typename T>
+    void set_detail(const std::string& name, const T& value);
+
+private:
+    msgpack::zone m_zone;
+    std::map<std::string, msgpack::object> m_details;
+};
+
+inline wamp_result_details::wamp_result_details()
+    : m_zone()
+    , m_details()
+{
+}
+
+inline wamp_result_details::~wamp_result_details()
+{
+}
+
+template <typename T>
+T wamp_result_details::get_detail(const std::string& name) const
+{
+    const auto detail_itr = m_details.find(name);
+    if (detail_itr == m_details.end()) {
+        throw std::invalid_argument("invalid detail requested: " + name);
+    }
+
+    return detail_itr->second.as<T>();
+}
+
+template <typename T>
+T wamp_result_details::get_detail_or(const std::string& name, const T& default_value) const
+{
+    const auto detail_itr = m_details.find(name);
+    if (detail_itr == m_details.end()) {
+        return default_value;
+    }
+
+    return detail_itr->second.as<T>();
+}
+
+template <typename T>
+void wamp_result_details::set_detail(const std::string& name, const T& value)
+{
+    m_details[name] = msgpack::object(value, m_zone);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_MESSAGES_WAMP_RESULT_DETAILS_HPP

--- a/src/bonefish/messages/wamp_result_message.hpp
+++ b/src/bonefish/messages/wamp_result_message.hpp
@@ -163,7 +163,7 @@ inline void wamp_result_message::set_request_id(const wamp_request_id& request_i
 
 inline void wamp_result_message::set_details(const msgpack::object& details)
 {
-    if (details.type != msgpack::type::MAP) {
+    if (details.type == msgpack::type::MAP) {
         m_details = msgpack::object(details, get_zone());
     } else {
         throw std::invalid_argument("invalid details");

--- a/src/bonefish/messages/wamp_yield_options.cpp
+++ b/src/bonefish/messages/wamp_yield_options.cpp
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bonefish/messages/wamp_yield_options.hpp>
+
+#include <stdexcept>
+
+namespace bonefish {
+
+msgpack::object wamp_yield_options::marshal(msgpack::zone& zone) const
+{
+    return msgpack::object(m_options, zone);
+}
+
+void wamp_yield_options::unmarshal(const msgpack::object& object)
+{
+    object.convert(m_options);
+}
+
+} // namespace bonefish

--- a/src/bonefish/messages/wamp_yield_options.hpp
+++ b/src/bonefish/messages/wamp_yield_options.hpp
@@ -1,0 +1,89 @@
+/**
+ *  Copyright (C) 2015 Topology LP
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef BONEFISH_MESSAGES_WAMP_YIELD_OPTIONS_HPP
+#define BONEFISH_MESSAGES_WAMP_YIELD_OPTIONS_HPP
+
+#include <msgpack.hpp>
+#include <string>
+#include <map>
+
+namespace bonefish {
+
+class wamp_yield_options
+{
+public:
+    wamp_yield_options();
+    virtual ~wamp_yield_options();
+
+    msgpack::object marshal(msgpack::zone& zone) const;
+    void unmarshal(const msgpack::object& options);
+
+    template <typename T>
+    T get_option(const std::string& name) const;
+
+    template <typename T>
+    T get_option_or(const std::string& name, const T& default_value) const;
+
+    template <typename T>
+    void set_option(const std::string& name, const T& value);
+
+private:
+    msgpack::zone m_zone;
+    std::map<std::string, msgpack::object> m_options;
+};
+
+inline wamp_yield_options::wamp_yield_options()
+    : m_zone()
+    , m_options()
+{
+}
+
+inline wamp_yield_options::~wamp_yield_options()
+{
+}
+
+template <typename T>
+T wamp_yield_options::get_option(const std::string& name) const
+{
+    const auto option_itr = m_options.find(name);
+    if (option_itr == m_options.end()) {
+        throw std::invalid_argument("invalid option requested: " + name);
+    }
+
+    return option_itr->second.as<T>();
+}
+
+template <typename T>
+T wamp_yield_options::get_option_or(const std::string& name, const T& default_value) const
+{
+    const auto option_itr = m_options.find(name);
+    if (option_itr == m_options.end()) {
+        return default_value;
+    }
+
+    return option_itr->second.as<T>();
+}
+
+template <typename T>
+void wamp_yield_options::set_option(const std::string& name, const T& value)
+{
+    m_options[name] = msgpack::object(value, m_zone);
+}
+
+} // namespace bonefish
+
+#endif // BONEFISH_MESSAGES_WAMP_YIELD_OPTIONS_HPP

--- a/src/bonefish/router/wamp_router_impl.cpp
+++ b/src/bonefish/router/wamp_router_impl.cpp
@@ -56,6 +56,7 @@ wamp_router_impl::wamp_router_impl(boost::asio::io_service& io_service, const st
 
     // Setup the dealer role and supported features
     wamp_role_features dealer_features;
+    dealer_features.set_attribute("progressive_call_results", true);
     dealer_features.set_attribute("call_timeout", true);
 
     wamp_role dealer_role(wamp_role_type::DEALER);


### PR DESCRIPTION
This commit adds in advanced profile support for progressive
call results. This allows for large result sets to be returned
to a caller in smaller chunks. It includes several small fixes
as well related to call processing. Big thanks to @estan and
@pramukta for helping put this together.

Resolves: #9
