### PR TITLE
Fix warnings/errors on latest clang/Xcode 7.3

### DIFF
--- a/src/bonefish/broker/wamp_broker.cpp
+++ b/src/bonefish/broker/wamp_broker.cpp
@@ -137,7 +137,7 @@ void wamp_broker::process_publish_message(const wamp_session_id& session_id,
                 event_message->set_arguments_kw(
                     msgpack::object(publish_message->get_arguments_kw(), event_message->get_zone()));
             } else {
-                event_message.reset(new wamp_event_message(std::move(publish_message->release_zone())));
+                event_message.reset(new wamp_event_message(publish_message->release_zone()));
                 event_message->set_subscription_id(subscription_id);
                 event_message->set_publication_id(publication_id);
                 event_message->set_arguments(publish_message->get_arguments());
@@ -192,7 +192,7 @@ void wamp_broker::process_subscribe_message(const wamp_session_id& session_id,
     m_session_subscriptions[session_id].insert(subscription_id);
 
     std::unique_ptr<wamp_subscribed_message> subscribed_message(
-            new wamp_subscribed_message(std::move(subscribe_message->release_zone())));
+            new wamp_subscribed_message(subscribe_message->release_zone()));
     subscribed_message->set_request_id(subscribe_message->get_request_id());
     subscribed_message->set_subscription_id(subscription_id);
 
@@ -245,7 +245,7 @@ void wamp_broker::process_unsubscribe_message(const wamp_session_id& session_id,
     }
 
     std::unique_ptr<wamp_unsubscribed_message> unsubscribed_message(
-            new wamp_unsubscribed_message(std::move(unsubscribe_message->release_zone())));
+            new wamp_unsubscribed_message(unsubscribe_message->release_zone()));
     unsubscribed_message->set_request_id(unsubscribe_message->get_request_id());
 
     BONEFISH_TRACE("%1%, %2%", *session_itr->second % *unsubscribed_message);

--- a/src/bonefish/dealer/wamp_dealer.cpp
+++ b/src/bonefish/dealer/wamp_dealer.cpp
@@ -209,7 +209,7 @@ void wamp_dealer::process_call_message(const wamp_session_id& session_id,
     }
 
     std::unique_ptr<wamp_invocation_message> invocation_message(
-            new wamp_invocation_message(std::move(call_message->release_zone())));
+            new wamp_invocation_message(call_message->release_zone()));
     invocation_message->set_request_id(request_id);
     invocation_message->set_registration_id(registration_id);
     invocation_message->set_details(invocation_details.marshal(invocation_message->get_zone()));
@@ -266,7 +266,7 @@ void wamp_dealer::process_error_message(const wamp_session_id& session_id,
     const auto& dealer_invocation = pending_invocations_itr->second;
 
     std::unique_ptr<wamp_error_message> caller_error_message(
-            new wamp_error_message(std::move(error_message->release_zone())));
+            new wamp_error_message(error_message->release_zone()));
     caller_error_message->set_request_type(wamp_message_type::CALL);
     caller_error_message->set_request_id(dealer_invocation->get_request_id());
     caller_error_message->set_details(error_message->get_details());
@@ -334,7 +334,7 @@ void wamp_dealer::process_register_message(const wamp_session_id& session_id,
     m_registered_procedures[registration_id] = procedure;
 
     std::unique_ptr<wamp_registered_message> registered_message(
-            new wamp_registered_message(std::move(register_message->release_zone())));
+            new wamp_registered_message(register_message->release_zone()));
     registered_message->set_request_id(register_message->get_request_id());
     registered_message->set_registration_id(registration_id);
 
@@ -397,7 +397,7 @@ void wamp_dealer::process_unregister_message(const wamp_session_id& session_id,
     registrations.erase(registrations_itr);
 
     std::unique_ptr<wamp_unregistered_message> unregistered_message(
-            new wamp_unregistered_message(std::move(unregister_message->release_zone())));
+            new wamp_unregistered_message(unregister_message->release_zone()));
     unregistered_message->set_request_id(unregister_message->get_request_id());
 
     // If we fail to send the unregistered message it is most likely that
@@ -452,7 +452,7 @@ void wamp_dealer::process_yield_message(const wamp_session_id& session_id,
     }
 
     std::unique_ptr<wamp_result_message> result_message(
-            new wamp_result_message(std::move(yield_message->release_zone())));
+            new wamp_result_message(yield_message->release_zone()));
     result_message->set_request_id(dealer_invocation->get_request_id());
     result_message->set_details(result_details.marshal(result_message->get_zone()));
     result_message->set_arguments(yield_message->get_arguments());

--- a/src/bonefish/native/native_message_queue.hpp
+++ b/src/bonefish/native/native_message_queue.hpp
@@ -97,7 +97,7 @@ inline void native_message_queue::push_message(
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_messages.push_back(
-            std::move(message(std::move(fields), std::move(zone))));
+            message(std::move(fields), std::move(zone)));
 }
 
 inline void native_message_queue::pop_message(

--- a/src/bonefish/native/native_transport.cpp
+++ b/src/bonefish/native/native_transport.cpp
@@ -34,8 +34,8 @@ bool native_transport::send_message(wamp_message&& message)
 {
     BONEFISH_TRACE("sending message: %1%", message_type_to_string(message.get_type()));
     m_connection->send_message(
-            std::move(message.marshal()),
-            std::move(message.release_zone()));
+            message.marshal(),
+            message.release_zone());
 
     return true;
 }


### PR DESCRIPTION
Prevent copy elision warnings [-Wpessimizing-move] by removing redundant std::move calls
